### PR TITLE
【功能】实现文章分类功能表单验证

### DIFF
--- a/branches/issue-8/文章分类3.txt
+++ b/branches/issue-8/文章分类3.txt
@@ -1,0 +1,152 @@
+// 获取表单元素
+const form = document.getElementById('categoryForm');
+const categoryNameInput = document.getElementById('categoryName');
+const categoryDescriptionInput = document.getElementById('categoryDescription');
+const fileInput = document.getElementById('fileUpload');
+
+// 提交事件监听器
+form.addEventListener('submit', (event) => {
+  event.preventDefault(); // 阻止默认提交
+
+  // 表单验证
+  const isValid = validateForm();
+
+  if (isValid) {
+    // 表单验证通过，提交表单
+    alert('分类信息提交成功');
+    form.submit(); // 提交表单
+  }
+});
+
+// 表单验证函数
+function validateForm() {
+  let isValid = true;
+
+  // 验证分类名称（必填，最多 50 字符）
+  if (!categoryNameInput.value.trim()) {
+    showError(categoryNameInput, '分类名称不能为空');
+    isValid = false;
+  } else if (categoryNameInput.value.length > 50) {
+    showError(categoryNameInput, '分类名称不能超过 50 个字符');
+    isValid = false;
+  } else {
+    clearError(categoryNameInput);
+  }
+
+  // 验证分类描述（可选，最多 200 字符）
+  if (categoryDescriptionInput.value.length > 200) {
+    showError(categoryDescriptionInput, '分类描述不能超过 200 个字符');
+    isValid = false;
+  } else {
+    clearError(categoryDescriptionInput);
+  }
+
+  // 验证附件上传（可选，限制为 JPEG 或 PNG 格式，最大 5MB）
+  if (fileInput.files.length > 0) {
+    const file = fileInput.files[0];
+    const fileType = file.type;
+    const fileSize = file.size;
+
+    if (!['image/jpeg', 'image/png'].includes(fileType)) {
+      showError(fileInput, '只能上传 JPEG 或 PNG 格式的文件');
+      isValid = false;
+    } else if (fileSize > 5 * 1024 * 1024) { // 限制 5MB
+      showError(fileInput, '文件大小不能超过 5MB');
+      isValid = false;
+    } else {
+      clearError(fileInput);
+    }
+  }
+
+  return isValid;
+}
+
+// 显示错误信息
+function showError(input, message) {
+  const errorElement = input.nextElementSibling;
+  errorElement.textContent = message;
+  errorElement.classList.add('error');
+}
+
+// 清除错误信息
+function clearError(input) {
+  const errorElement = input.nextElementSibling;
+  errorElement.textContent = '';
+  errorElement.classList.remove('error');
+}
+// 获取表单元素
+const form = document.getElementById('categoryForm');
+const categoryNameInput = document.getElementById('categoryName');
+const categoryDescriptionInput = document.getElementById('categoryDescription');
+const fileInput = document.getElementById('fileUpload');
+
+// 提交事件监听器
+form.addEventListener('submit', (event) => {
+  event.preventDefault(); // 阻止默认提交
+
+  // 表单验证
+  const isValid = validateForm();
+
+  if (isValid) {
+    // 表单验证通过，提交表单
+    alert('分类信息提交成功');
+    form.submit(); // 提交表单
+  }
+});
+
+// 表单验证函数
+function validateForm() {
+  let isValid = true;
+
+  // 验证分类名称（必填，最多 50 字符）
+  if (!categoryNameInput.value.trim()) {
+    showError(categoryNameInput, '分类名称不能为空');
+    isValid = false;
+  } else if (categoryNameInput.value.length > 50) {
+    showError(categoryNameInput, '分类名称不能超过 50 个字符');
+    isValid = false;
+  } else {
+    clearError(categoryNameInput);
+  }
+
+  // 验证分类描述（可选，最多 200 字符）
+  if (categoryDescriptionInput.value.length > 200) {
+    showError(categoryDescriptionInput, '分类描述不能超过 200 个字符');
+    isValid = false;
+  } else {
+    clearError(categoryDescriptionInput);
+  }
+
+  // 验证附件上传（可选，限制为 JPEG 或 PNG 格式，最大 5MB）
+  if (fileInput.files.length > 0) {
+    const file = fileInput.files[0];
+    const fileType = file.type;
+    const fileSize = file.size;
+
+    if (!['image/jpeg', 'image/png'].includes(fileType)) {
+      showError(fileInput, '只能上传 JPEG 或 PNG 格式的文件');
+      isValid = false;
+    } else if (fileSize > 5 * 1024 * 1024) { // 限制 5MB
+      showError(fileInput, '文件大小不能超过 5MB');
+      isValid = false;
+    } else {
+      clearError(fileInput);
+    }
+  }
+
+  return isValid;
+}
+
+// 显示错误信息
+function showError(input, message) {
+  const errorElement = input.nextElementSibling;
+  errorElement.textContent = message;
+  errorElement.classList.add('error');
+}
+
+// 清除错误信息
+function clearError(input) {
+  const errorElement = input.nextElementSibling;
+  errorElement.textContent = '';
+  errorElement.classList.remove('error');
+}


### PR DESCRIPTION
该 PR 实现了文章分类页面的表单验证功能，确保用户提交的分类名称和描述符合规定的输入要求。具体包括：验证分类名称是否为空，并且长度不能超过 50 个字符；验证分类描述的最大长度不能超过 200 个字符；实现附件上传功能的验证，限制文件格式为 JPEG 或 PNG，且文件大小不能超过5MB。此功能确保用户提交的数据符合要求，提高了表单的健壮性和用户体验。closes #8 